### PR TITLE
Update GitHub action versions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Get npm package version
       id: version
       uses: martinbeentjes/npm-get-version-action@v1.0.0
@@ -26,10 +26,10 @@ jobs:
         version_key: ${{ steps.version.outputs.current-version }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to Google Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: us.gcr.io
         username: _json_key
@@ -37,7 +37,7 @@ jobs:
 
     - name: Publish Docker image
       id: build_push_action
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: true
         tags: us.gcr.io/${{ env.CONTAINER_OWNER }}/${{ env.CONTAINER_IMAGE_NAME }}:${{ steps.version.outputs.current-version }}-rc${{ steps.rc.outputs.version_build_number }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -40,6 +40,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: true
+        provenance: false
         tags: us.gcr.io/${{ env.CONTAINER_OWNER }}/${{ env.CONTAINER_IMAGE_NAME }}:${{ steps.version.outputs.current-version }}-rc${{ steps.rc.outputs.version_build_number }}
 
     - name: Display Docker image


### PR DESCRIPTION
This updates some actions to fix deprecation warnings.  Packaging changes are untested.  Ones without updates yet are:
- https://github.com/martinbeentjes/npm-get-version-action
- https://github.com/zyborg/gh-action-buildnum