### PR TITLE
Prevent popup block of dialog for URL-based credential handlers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # authn.io ChangeLog
 
+## 5.1.2 - 2023-03-dd
+
+### Fixed
+- Fix popup blocking of dialog for credential handlers that receive
+  requests via URL.
+
 ## 5.1.1 - 2023-03-12
 
 ### Fixed

--- a/web/mediator/constants.js
+++ b/web/mediator/constants.js
@@ -1,0 +1,13 @@
+/*!
+ * New BSD License (3-clause)
+ * Copyright (c) 2017-2023, Digital Bazaar, Inc.
+ * All rights reserved.
+ */
+export const DEFAULT_ALLOW_WALLET_POPUP_WIDTH = 500;
+export const DEFAULT_ALLOW_WALLET_POPUP_HEIGHT = 240;
+
+export const DEFAULT_HANDLER_POPUP_WIDTH = 800;
+export const DEFAULT_HANDLER_POPUP_HEIGHT = 600;
+
+export const DEFAULT_HINT_CHOOSER_POPUP_WIDTH = 500;
+export const DEFAULT_HINT_CHOOSER_POPUP_HEIGHT = 440;


### PR DESCRIPTION
- The window used for credential handlers that register to receive requests via URL must be opened before the next turn of the event loop in some browsers. Therefore, when a hint is selected in a mediator first party dialog and that hint is for such a URL-based credential handler, the window for it will be opened from the first party dialog immediately to prevent it from being blocked.