### PR TITLE
Do not show any mediator UI when `hide()` is called.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # authn.io ChangeLog
 
+## 5.2.1 - 2023-08-dd
+
+### Fixed
+- Do not show any mediator UI when `hide()` is called.
+
 ## 5.2.0 - 2023-03-23
 
 ### Added

--- a/web/components/FirstPartyMediatorWizard.vue
+++ b/web/components/FirstPartyMediatorWizard.vue
@@ -1,8 +1,8 @@
 <template>
   <!-- blank screen once hint is selected and wallet window is loading -->
-  <div v-if="selectedHint" />
+  <div v-if="show && selectedHint" />
   <MediatorWizard
-    v-else
+    v-else-if="show"
     :can-web-share="canWebShare"
     :credential-request-origin="credentialRequestOrigin"
     :credential-request-origin-manifest="credentialRequestOriginManifest"
@@ -44,6 +44,7 @@ export default {
     const loading = ref(true);
     const requestType = ref('');
     const selectedHint = ref(null);
+    const show = ref(true);
 
     const showHintChooser = computed(() => {
       return requestType.value !== 'permissionRequest';
@@ -88,6 +89,7 @@ export default {
       try {
         await mediator.initialize({
           show: ({requestType: _requestType}) => {
+            show.value = true;
             loading.value = true;
             requestType.value = _requestType;
 
@@ -96,6 +98,7 @@ export default {
               .then(({enabled}) => canWebShare.value = enabled);
           },
           hide: () => {
+            show.value = false;
             hints.value = [];
             loading.value = false;
             requestType.value = '';
@@ -117,7 +120,7 @@ export default {
     return {
       // data
       canWebShare, credentialRequestOrigin, credentialRequestOriginManifest,
-      hints, loading, requestType, selectedHint, showHintChooser,
+      hints, loading, requestType, selectedHint, show, showHintChooser,
       // methods
       allow, cancel, deny, removeHint, selectHint, webShare
     };

--- a/web/components/ThirdPartyMediatorWizard.vue
+++ b/web/components/ThirdPartyMediatorWizard.vue
@@ -1,5 +1,6 @@
 <template>
   <MediatorWizard
+    v-if="show"
     :can-web-share="canWebShare"
     :credential-request-origin="credentialRequestOrigin"
     :credential-request-origin-manifest="credentialRequestOriginManifest"
@@ -63,6 +64,7 @@ export default {
     const rememberChoice = ref(true);
     const requestType = ref('');
     const selectedHint = ref(null);
+    const show = ref(true);
 
     const showHintChooser = computed(() =>
       hasStorageAccess.value && requestType.value !== 'permissionRequest');
@@ -139,6 +141,7 @@ export default {
       try {
         await mediator.initialize({
           show: ({requestType: _requestType}) => {
+            show.value = true;
             loading.value = true;
             requestType.value = _requestType;
 
@@ -147,6 +150,7 @@ export default {
               .then(({enabled}) => canWebShare.value = enabled);
           },
           hide: () => {
+            show.value = false;
             hints.value = [];
             loading.value = false;
             firstPartyDialogOpen.value = false;
@@ -172,7 +176,7 @@ export default {
       // data
       canWebShare, credentialRequestOrigin, credentialRequestOriginManifest,
       firstPartyDialogOpen, hasStorageAccess, hints, loading,
-      rememberChoice, requestType, selectedHint, showHintChooser,
+      rememberChoice, requestType, selectedHint, show, showHintChooser,
       // methods
       allow, cancel, deny, focusFirstPartyDialog, openFirstPartyDialog,
       removeHint, selectHint, webShare


### PR DESCRIPTION
Addresses #141.