### PR TITLE
Accomodate manifest.json & manifest.webmanifest files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # authn.io ChangeLog
 
-## 7.2.0 - 2024-02-dd
+## 7.1.0 - 2024-02-dd
 
 ### Added
 - Load web app manifests from both `manifest.json` and `manifest.webmanifest` files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # authn.io ChangeLog
 
+## 7.0.1 - 2024-02-dd
+
+### Fixed
+- Load both manifest.json and manifest.webmanifest files.
+
 ## 7.0.0 - 2023-11-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # authn.io ChangeLog
 
-## 7.0.1 - 2024-02-dd
+## 7.2.0 - 2024-02-dd
 
-### Fixed
-- Load both manifest.json and manifest.webmanifest files.
+### Added
+- Load web app manifests from both `manifest.json` and `manifest.webmanifest` files.
 
 ## 7.0.0 - 2023-11-27
 

--- a/web/mediator/manifest.js
+++ b/web/mediator/manifest.js
@@ -27,7 +27,7 @@ async function _getWebAppManifest({origin}) {
   ];
   const responses = await Promise.allSettled(urls.map(_fetchWithCache));
   const response = responses.find(({value}) => value !== null);
-  return response.value || null;
+  return response?.value || null;
 }
 
 async function _parseBody(response) {

--- a/web/mediator/manifest.js
+++ b/web/mediator/manifest.js
@@ -25,9 +25,7 @@ async function _getWebAppManifest({origin}) {
     `${origin}/manifest.json`,
     `${origin}/manifest.webmanifest`
   ];
-  const responses = await Promise.allSettled(
-    urls.map(url => _fetchWithCache(url))
-  );
+  const responses = await Promise.allSettled(urls.map(_fetchWithCache));
   const response = responses.find(({value}) => value !== null);
   return response.value || null;
 }

--- a/web/mediator/manifest.js
+++ b/web/mediator/manifest.js
@@ -20,13 +20,43 @@ export async function getWebAppManifest({origin, timeout = 1000}) {
 }
 
 async function _getWebAppManifest({origin}) {
-  let url;
-  let response;
+  // urls are in order of priority
   const urls = [
-    `${origin}/manifest.json`
-    `${origin}/manifest.webmanifest`,
+    `${origin}/manifest.json`,
+    `${origin}/manifest.webmanifest`
   ];
+  const responses = await Promise.allSettled(
+    urls.map(url => _fetchWithCache(url))
+  );
+  const response = responses.find(({value}) => value !== null);
+  return response.value || null;
+}
 
+async function _parseBody(response) {
+  if(!response.ok) {
+    throw new Error(
+      `Response: ${response.status} ${response.statusText}`);
+  }
+  if(!_isContentJson(response)) {
+    throw new Error('Content is not JSON.');
+  }
+  return response.json();
+}
+
+function _isContentJson(response) {
+  const {type} = contentType.parse(response.headers.get('content-type'));
+  return ['application/manifest+json', 'application/json'].includes(type);
+}
+
+async function _legacyFetch(url) {
+  const response = await httpClient.get(url, {credentials: 'omit'});
+  if(!_isContentJson(response)) {
+    throw new Error('Content is not JSON.');
+  }
+  return response.data;
+}
+
+async function _fetchWithCache(url) {
   try {
     if(!cacheStorage && typeof caches !== 'undefined') {
       try {
@@ -37,37 +67,26 @@ async function _getWebAppManifest({origin}) {
     }
     if(!cacheStorage) {
       // no cache storage/API available, fetch directly
-      return await _legacyFetch(urls);
+      return await _legacyFetch(url);
     }
 
-    // iterate through urls for cached response
-    for(let i = 0; i < urls.length; i++) {
-      const url = urls[i];
-      // try to get cached response
-      response = await cacheStorage.match(url);
-      if(response) {
-        const expires = new Date(response.headers.get('expires'));
-        const now = new Date();
-        if(expires >= now) {
-          // return cached response
-          return await _parseBody(response);
-        }
-        // remove expired response from cache
-        await cacheStorage.delete(url);
+    // try to get cached response
+    let response = await cacheStorage.match(url);
+    if(response) {
+      const expires = new Date(response.headers.get('expires'));
+      const now = new Date();
+      if(expires >= now) {
+        // return cached response
+        return await _parseBody(response);
       }
+      // remove expired response from cache
+      await cacheStorage.delete(url);
     }
 
     let fetchError;
     try {
-      // fetch live responses
-      const allResponses = await Promise.allSettled(
-        urls.map(url => fetch(url, {credentials: 'omit'}))
-      );
-      const successfulResponse = allResponses.find(({status, value}) => {
-        return status === 'fulfilled' && value.ok;
-      });
-      response = successfulResponse.value;
-      url = successfulResponse.value.url;
+      // fetch live response
+      response = await fetch(url, {credentials: 'omit'});
 
       // build a cached response that will expire based on local config
       const headers = new Headers(response.headers);
@@ -121,34 +140,4 @@ async function _getWebAppManifest({origin}) {
       `Fixing this may improve the information displayed for "${origin}".`, e);
     return null;
   }
-}
-
-async function _parseBody(response) {
-  if(!response.ok) {
-    throw new Error(
-      `Response: ${response.status} ${response.statusText}`);
-  }
-  if(!_isContentJson(response)) {
-    throw new Error('Content is not JSON.');
-  }
-  return response.json();
-}
-
-function _isContentJson(response) {
-  const {type} = contentType.parse(response.headers.get('content-type'));
-  return ['application/manifest+json', 'application/json'].includes(type);
-}
-
-async function _legacyFetch(urls) {
-  const allResponses = await Promise.allSettled(
-    urls.map(url => httpClient.get(url, {credentials: 'omit'}))
-  );
-  const successfulResponse = allResponses.find(({status, value}) => {
-    return status === 'fulfilled' && value.ok;
-  });
-  const response = successfulResponse.value;
-  if(!_isContentJson(response)) {
-    throw new Error('Content is not JSON.');
-  }
-  return response.data;
 }


### PR DESCRIPTION
#### _Resolves TODO_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Bug fix.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- Only manifest.json is loaded.

<br/>

### What is the new behavior?

- Both manifest.json and manifest.webmanifest are retrieved, whichever returns first with data is utilized.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- I created a local server that contained both files and fetched them with authn.io. I was able to use whichever one was present and came back the fastest.

<br/>

### Screenshots:

> n/a